### PR TITLE
ローカルでのDBコンテナ起動がコケる現象を解決する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
             docker-compose logs
             docker-compose run --rm app bash -c "python --version && poetry --version"
             docker-compose run --rm db bash -c "psql --version"
-            docker-compose exec db bash
 
       - run:
           name: Run Pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,12 @@ jobs:
           command: |
             set -x
             docker-compose up -d
+            sleep 5
+            docker ps -f status=running
+            docker-compose logs
             docker-compose run --rm app bash -c "python --version && poetry --version"
             docker-compose run --rm db bash -c "psql --version"
             docker-compose exec db bash
-            exit
-            sleep 10
-            docker ps -f status=running
-            docker-compose logs
 
       - run:
           name: Run Pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
     machine:
       image: ubuntu-1604:202007-01
 
-    working_directory: ~/app
-
     steps:
       - checkout
 
@@ -22,20 +20,17 @@ jobs:
             docker-compose build
 
       - run:
-          name: Up Docker container
+          name: Up Docker containers and Confirm logs
           command: |
             set -x
             docker-compose up -d
-            docker-compose run --rm app sh -c "python --version && poetry --version"
-
-      # - run:
-      #     name: Run Docker container
-      #     command: |
-      #       set -x
-      #       docker-compose up -d
-      #       sleep 10
-      #       docker ps -f status=running
-      #       docker-compose logs
+            docker-compose run --rm app bash -c "python --version && poetry --version"
+            docker-compose run --rm db bash -c "psql --version"
+            docker-compose exec db bash
+            exit
+            sleep 10
+            docker ps -f status=running
+            docker-compose logs
 
       - run:
           name: Run Pytest

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Setting by User
+db/tmp

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,3 @@
 FROM postgres:12-alpine
 
-EXPOSE 5432
-CMD ["postgres"]
+ENV LANG ja_JP.utf8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,5 @@
 version: "3"
 services:
-  postgres:
-    build: ./db
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=password
-    ports:
-      - "5432:5432"
-    volumes:
-      - ./db/data/postgres:/var/lib/postgresql/data
   app:
     build: ./app
     user: root
@@ -24,3 +15,14 @@ services:
         --allow-root
         --NotebookApp.token=''
         --no-browser
+  db:
+    build: ./db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=testdb
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./db/tmp/postgres/data:/var/lib/postgresql/data
+    restart: always


### PR DESCRIPTION
# 概要

現状では、ローカル開発環境（macOS）において、 'docker-compose up' でのPostgresコンテナ起動が失敗するケースが発生しているため、これを解決する

1.
  - クラウド環境（Linux）
  - CIビルド

  では問題なくビルド成功しているので、ローカルでも起動できるよう微修正を加えていく

2.
  上記事情があるため、既存ファイルにはなるべく手をつけず（最小限の修正で）解決できるよう改善実装する

## 参考

リポジトリ https://github.com/miolab/psql_docker_sandbox/pull/2 で検証完了しており、こちらの実装結果をもとに進めていく
